### PR TITLE
[Fix] Run 1.2.1.2 only if requestBody exist for method

### DIFF
--- a/public/rulesets/default/1_2_1_API_Format_Specifications.yaml
+++ b/public/rulesets/default/1_2_1_API_Format_Specifications.yaml
@@ -31,5 +31,6 @@ rules:
           - name: "Content-Type"
             valueType: string
             in: header
+        checkMethodIfSectionExist: requestBody
     severity: high
     status: implemented

--- a/src/functions/checkParamElementPresence.ts
+++ b/src/functions/checkParamElementPresence.ts
@@ -8,8 +8,9 @@ export function checkParamElementPresence(spec: any, content: string, rule: any)
     if (!spec?.paths) return diagnostics;
 
     const seen = new Set<string>();
-
+    const checkOnlyIf = rule.call.functionParams.checkMethodIfSectionExist || "";
     const excludedPaths = rule.call.functionParams.exceptionPaths || [];
+
     for (const path in spec.paths) {
         if (excludedPaths.includes(path)) continue;
         const pathItem = spec.paths[path];
@@ -18,6 +19,8 @@ export function checkParamElementPresence(spec: any, content: string, rule: any)
         for (const method of methodsToCheck) {
             const operation = pathItem[method];
             if (!operation || typeof operation !== "object") continue;
+
+            if (checkOnlyIf && !operation[checkOnlyIf]) continue;
 
             const key = `${path}|${method}`;
             if (seen.has(key)) continue;


### PR DESCRIPTION
No need to run this rule for get and other methods where requestBody not used