### PR TITLE
[Feat.] Add checkGetIdempotency rule - 2.4.1.3

### DIFF
--- a/public/rulesets/default/2_4_1_Request_Verb_And_Response_Status_Code.yaml
+++ b/public/rulesets/default/2_4_1_Request_Verb_And_Response_Status_Code.yaml
@@ -41,25 +41,24 @@ rules:
       GET operations must not modify server-side data or state. They must not have a request body or have action keywords in path.
     option: Mandatory
     location: paths
-    element:
-      - get
+    element: get
     call:
       function: checkGetIdempotency
       functionParams:
         disallowedPathKeywords:
-          - create
-          - update
-          - delete
-          - restart
-          - trigger
-          - action
-          - execute
-          - run
-          - reset
-          - change
+          - "create"
+          - "update"
+          - "delete"
+          - "restart"
+          - "trigger"
+          - "action"
+          - "execute"
+          - "run"
+          - "reset"
+          - "change"
         disallowRequestBody: true
     description: Check whether GET operation has request body or action keywords in path.
-    status: devel    
+    status: implemented
     severity: critical
 
   - id: 2.4.1.4

--- a/src/components/Linter.tsx
+++ b/src/components/Linter.tsx
@@ -8,6 +8,7 @@ import { checkOASSpec } from "@/functions/checkOASSpec";
 import { checkOASVersion } from "@/functions/checkOASVersion";
 import { checkCRUD } from "@/functions/checkCRUD";
 import { checkSuccessResponse } from "@/functions/checkSuccessResponse";
+import { checkGetIdempotency } from "@/functions/checkGetIdempotency";
 
 const functionsMap: { [key: string]: (spec: any, content: string, rule: any) => Diagnostic[] } = {
     checkHttpsServers,
@@ -18,6 +19,7 @@ const functionsMap: { [key: string]: (spec: any, content: string, rule: any) => 
     checkOASVersion,
     checkCRUD,
     checkSuccessResponse,
+    checkGetIdempotency
 };
 
 export function openApiLinter(selectedRules: any) {

--- a/src/functions/checkGetIdempotency.ts
+++ b/src/functions/checkGetIdempotency.ts
@@ -1,0 +1,37 @@
+import { Diagnostic } from "@codemirror/lint";
+import { mapSeverity } from "@/utils/mapSeverity";
+import { findMethodPositionInYaml } from "@/utils/pos";
+
+export function checkGetIdempotency(spec: any, content: string, rule: any): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    const disallowedPathKeywords: string[] = rule.call.functionParams.disallowedPathKeywords || [];
+    const disallowRequestBody: boolean = rule.call.functionParams.disallowRequestBody === true;
+
+    if (!spec?.paths) return diagnostics;
+
+    for (const path in spec.paths) {
+        const pathItem = spec.paths[path];
+        const operation = pathItem.get;
+        if (!operation || typeof operation !== "object") continue;
+
+        const keywords = disallowedPathKeywords.map(k => k.toLowerCase());
+        const pathLower = path.toLowerCase();
+
+        const hasDisallowedKeyword = keywords.some(keyword => pathLower.includes(keyword));
+        const hasRequestBody = disallowRequestBody && "requestBody" in operation;
+
+        if (hasDisallowedKeyword || hasRequestBody) {
+            const { start, end } = findMethodPositionInYaml(content, path, "get");
+            diagnostics.push({
+                from: start,
+                to: end,
+                severity: mapSeverity(rule.severity),
+                message: rule.message,
+                source: rule.id,
+            });
+        }
+    }
+
+    return diagnostics;
+}


### PR DESCRIPTION
Implements:
  - id: 2.4.1.3
    title: GET operations must be secure and idempotent