### PR TITLE
[Feat.] Compatibility 2.1.7.3

### DIFF
--- a/public/gitea/repositories.yaml
+++ b/public/gitea/repositories.yaml
@@ -1,2 +1,3 @@
 services:
+  # title: ER must match to repo name where open API spec are stores
   - ER: enterprise-router

--- a/public/rulesets/default/2_1_7_Compatibility.yaml
+++ b/public/rulesets/default/2_1_7_Compatibility.yaml
@@ -36,21 +36,15 @@ rules:
 
   - id: 2.1.7.3
     title: "Compatibility: The interfaces must be compatible"
+    description: This rule compares whether new Mandatory request parameters have been added to existing API calls when comparing to previous version of OpenAPI specification.
     message: |
       Adding Mandatory Request Parameters to APIs
     option: Mandatory
     location: paths
     element: requestBody
     call:
-      function: DiffPreviousRelease
-      functionParams:
-        parameter_type:
-          - "required"
-        action:
-          - "add"
-        previousVersionRef: "https://github.com/opentelekomcloud-docs/"
-    description: This rule compares whether new Mandatory request parameters have been added to existing API calls when comparing to previous version of OpenAPI specification. 
-    status: devel
+      function: checkCompatibility
+    status: implemented
     severity: critical
 
   - id: 2.1.7.4


### PR DESCRIPTION
Added:
  - id: 2.1.7.3
    title: "Compatibility: The interfaces must be compatible"
    description: This rule compares whether new Mandatory request parameters have been added to existing API calls when comparing to previous version of OpenAPI specification.