### PR TITLE
[Feat.] New apis, update validate api

### DIFF
--- a/src/clients/reportportal.ts
+++ b/src/clients/reportportal.ts
@@ -68,6 +68,74 @@ export class ReportPortalClient {
     console.log(text)
     return text;
   }
+
+  /**
+   * Get launch details by numeric ID using the official ReportPortal Service API.
+   * API: GET /v1/:projectName/launch/:launchId
+   */
+  async getLaunchById(params: { project: string; launchId: number | string }): Promise<any> {
+    const { project, launchId } = params;
+
+    if (!this.endpoint || !this.apiKey) {
+      throw new Error('ReportPortal config missing on server: REPORTPORTAL_ENDPOINT/REPORTPORTAL_API_KEY');
+    }
+
+    const url = `${this.endpoint.replace(/\/$/, '')}/${project}/launch/${launchId}`;
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(text || `ReportPortal responded with status ${res.status}`);
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      // Fallback in case the server returns non-JSON content-type while still returning JSON string
+      return text as any;
+    }
+  }
+
+
+  /**
+   * Get all index clusters of the launch.
+   * API: GET /v1/:projectName/launch/cluster/:launchId
+   */
+  async getLaunchClusters(params: { project: string; launchId: number | string }): Promise<any> {
+    const { project, launchId } = params;
+
+    if (!this.endpoint || !this.apiKey) {
+      throw new Error('ReportPortal config missing on server: REPORTPORTAL_ENDPOINT/REPORTPORTAL_API_KEY');
+    }
+
+    const url = `${this.endpoint.replace(/\/$/, '')}/${project}/launch/cluster/${launchId}`;
+
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        Accept: 'application/json',
+      },
+    });
+
+    const text = await res.text();
+    if (!res.ok) {
+      throw new Error(text || `ReportPortal responded with status ${res.status}`);
+    }
+
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text as any;
+    }
+  }
 }
 
 export const reportPortalClient = new ReportPortalClient();

--- a/src/pages/api/reportportal.ts
+++ b/src/pages/api/reportportal.ts
@@ -11,52 +11,76 @@ export const config = {
 };
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
-  if (req.method !== 'POST') {
+  if (req.method !== 'POST' && req.method !== 'GET') {
     return res.status(405).json({ error: 'Method not allowed' });
   }
 
-  try {
-    // Next.js gives you an object for application/json, but if the client sent text/plain
-    // or a raw stringified JSON, req.body can be a string. Handle both.
-    let body: any = req.body;
-    if (typeof body === 'string') {
-      try {
-        body = JSON.parse(body);
-      } catch {
-        // Not JSON; keep as string and try to parse as URLSearchParams (common when sent as text/plain)
+  if (req.method === 'POST') {
+    try {
+      // Next.js gives you an object for application/json, but if the client sent text/plain
+      // or a raw stringified JSON, req.body can be a string. Handle both.
+      let body: any = req.body;
+      if (typeof body === 'string') {
         try {
-          const params = new URLSearchParams(body);
-          body = Object.fromEntries(params.entries());
+          body = JSON.parse(body);
         } catch {
-          return res.status(400).json({ error: 'Invalid request body. Expected JSON or form-encoded string.' });
+          // Not JSON; keep as string and try to parse as URLSearchParams (common when sent as text/plain)
+          try {
+            const params = new URLSearchParams(body);
+            body = Object.fromEntries(params.entries());
+          } catch {
+            return res.status(400).json({ error: 'Invalid request body. Expected JSON or form-encoded string.' });
+          }
         }
       }
+
+      const { xml, launch, description, attributes, mode, project } = body || {};
+
+      // Validate presence and non-empty strings
+      const missing: string[] = [];
+      if (!xml || (typeof xml === 'string' && xml.trim() === '')) missing.push('xml');
+      if (!launch || (typeof launch === 'string' && launch.trim() === '')) missing.push('launch');
+      if (!project || (typeof project === 'string' && project.trim() === '')) missing.push('project');
+
+      if (missing.length) {
+        return res.status(400).json({ error: `Missing required field(s): ${missing.join(', ')}` });
+      }
+
+      const result = await reportPortalClient.importLaunch({
+        xml,
+        project,
+        launch,
+        description,
+        attributes,
+        mode,
+      });
+
+      return res.status(200).json({ success: true, message: result });
+    } catch (error: any) {
+      console.error('ReportPortal proxy error:', error);
+      return res.status(500).json({ error: error?.message || 'Unknown error' });
     }
-
-    const { xml, launch, description, attributes, mode, project } = body || {};
-
-    // Validate presence and non-empty strings
-    const missing: string[] = [];
-    if (!xml || (typeof xml === 'string' && xml.trim() === '')) missing.push('xml');
-    if (!launch || (typeof launch === 'string' && launch.trim() === '')) missing.push('launch');
-    if (!project || (typeof project === 'string' && project.trim() === '')) missing.push('project');
-
-    if (missing.length) {
-      return res.status(400).json({ error: `Missing required field(s): ${missing.join(', ')}` });
-    }
-
-    const result = await reportPortalClient.importLaunch({
-      xml,
-      project,
-      launch,
-      description,
-      attributes,
-      mode,
-    });
-
-    return res.status(200).json({ success: true, message: result });
-  } catch (error: any) {
-    console.error('ReportPortal proxy error:', error);
-    return res.status(500).json({ error: error?.message || 'Unknown error' });
   }
+
+  if (req.method === 'GET') {
+    try {
+      const { project, launchId } = req.query;
+      if (!project || !launchId) {
+        return res.status(400).json({ error: 'Missing required query parameters: project and launchId' });
+      }
+
+      const result = await reportPortalClient.getLaunchById({
+        project: String(project),
+        launchId: String(launchId),
+      });
+
+      return res.status(200).json(result);
+    } catch (error: any) {
+      console.error('Error fetching launch by ID:', error);
+      return res.status(500).json({ error: error?.message || 'Unknown error' });
+    }
+  }
+
+  // This should not be reached, but in case
+  return res.status(500).json({ error: 'Unknown error' });
 }

--- a/src/pages/api/reportportal/clusters.ts
+++ b/src/pages/api/reportportal/clusters.ts
@@ -1,0 +1,30 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { reportPortalClient } from '@/clients/reportportal';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  if (req.method === 'GET') {
+    try {
+      const {project, launchId} = req.query;
+      if (!project || !launchId) {
+        return res.status(400).json({error: 'Missing required query parameters: project and launchId'});
+      }
+
+      const result = await reportPortalClient.getLaunchClusters({
+        project: String(project),
+        launchId: String(launchId),
+      });
+
+      return res.status(200).json(result);
+    } catch (error: any) {
+      console.error('Error fetching launch clusters:', error);
+      return res.status(500).json({error: error?.message || 'Unknown error'});
+    }
+  }
+
+  // This should not be reached, but in case
+  return res.status(500).json({ error: 'Unknown error' });
+}


### PR DESCRIPTION
New:

- Get launch details by numeric ID using the official ReportPortal Service API.
   API: GET /api/reportportal?project=name&launchId=12345
   Example response:
```
{
    "owner": "name",
    "description": "Latest launch for ER - 2025-10-29T10:40:54.587Z",
    "id": 1,
    "uuid": "12345",
    "name": "Service: ER",
    "number": 1,
    "startTime": "2025-10-29T10:40:55.017281Z",
    "endTime": "2025-10-29T11:41:35.709Z",
    "lastModified": "2025-10-29T10:40:58.104667Z",
    "status": "FAILED",
    "statistics": {
        "executions": {
            "total": 186,
            "passed": 16,
            "failed": 149,
            "skipped": 21
        },
        "defects": {
            "to_investigate": {
                "total": 170,
                "ti001": 170
            }
        }
    },
    "attributes": [],
    "mode": "DEFAULT",
    "analysing": [],
    "approximateDuration": 3633.297102,
    "hasRetries": false,
    "rerun": false,
    "metadata": {
        "rp.cluster.lastRun": "1761734463992"
    },
    "retentionPolicy": "REGULAR"
}
```
- Get all index clusters of the launch.
   API: GET /api/reportportal/clusters?project=name&launchId=12345
   Example response:
```
{
    "content": [
        {
            "id": 6186,
            "index": 76953492544259440,
            "launchId": 1,
            "message": "High Each resource-creating path POST must have corresponding GET PUT and DELETE operations for the same resource\nMissing get put delete",
            "matchedTests": 16
        },
        {
            "id": 6181,
            "index": 74130670293635940,
            "launchId": 1,
            "message": "Low All APIs must have x-apigateway-ratelimit defined",
            "matchedTests": 46
        },
        {
            "id": 6182,
            "index": 94171890430958110,
            "launchId": 1,
            "message": "Critical Token authentication uses X-Auth-Token request header to carry authentication information",
            "matchedTests": 46
        },
        {
            "id": 6183,
            "index": 54970441921488270,
            "launchId": 1,
            "message": "High If the request or response body is present the default media type must be application json or application bson",
            "matchedTests": 18
        },
        {
            "id": 6187,
            "index": 53282055868481740,
            "launchId": 1,
            "message": "Critical GET methods used to retrieve a list of resources must return a top-level array e g",
            "matchedTests": 8
        },
        {
            "id": 6184,
            "index": 38314838788369580,
            "launchId": 1,
            "message": "High If the request body is absent the default media type header must not be set",
            "matchedTests": 1
        },
        {
            "id": 6185,
            "index": 79255182386462800,
            "launchId": 1,
            "message": "Medium The response body must support JSON or BSON encapsulation If a body is present the Content-Type must be application json or application bson",
            "matchedTests": 14
        }
    ],
    "page": {
        "number": 1,
        "size": 20,
        "totalElements": 7,
        "totalPages": 1
    }
}
```

Updated:
- POST /api/validate to read spec from internal gitea urls