### PR TITLE
[Feat.] New rule URI-020-01-2507-2507-M-3

### DIFF
--- a/public/rulesets/default/Request_URI_Format.yaml
+++ b/public/rulesets/default/Request_URI_Format.yaml
@@ -57,8 +57,7 @@ rules:
   - id: "URI-020-01-2507-2507-M-3"
     title: URIs allow only nouns and use lowercase letters. Use few concatenated words.
     message: |
-      (3) Resource names in URIs must be separated by hyphens (-) and all letters must be lowercase.
-
+      Resource names in URIs must be separated by hyphens (-) and all letters must be lowercase.
     option: Mandatory
     location: paths
     element: path
@@ -66,9 +65,9 @@ rules:
       function: checkURIContentSyntax
       functionParams:
         requiredPathRegexp:
-#          - "^/(?:[a-z0-9]+(?:-[a-z0-9]+)*|\{[a-z0-9_]+\})(?:/(?:[a-z0-9]+(?:-[a-z0-9]+)*|\{[a-z0-9_]+\}))*$"
+          - '^/(?:[a-z0-9]+(?:-[a-z0-9]+)*|\{[a-z0-9_]+\})(?:/(?:[a-z0-9]+(?:-[a-z0-9]+)*|\{[a-z0-9_]+\}))*$'
     description: Check whether URI contains only lowercase characters separated by hyphens
-    status: planned
+    status: implemented
     severity: critical
 
   - id: "URI-030-01-2507-2507-M-1"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,6 +13,7 @@ import {exportJUnit, exportPDF, exportReportPortal} from "@/utils/export";
 import { getSeverityLabel, severityToDiagnosticMap } from "@/utils/mapSeverity";
 import "@telekom/scale-components/dist/scale-components/scale-components.css";
 import { applyPolyfills, defineCustomElements } from "@telekom/scale-components/loader";
+import {loadAllowedAbbreviationsFromApi} from "@/utils/englishWords";
 declare module 'react' {
   // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace JSX {
@@ -59,6 +60,10 @@ const HomePage = () => {
     const headerRef = useRef<HTMLDivElement>(null);
     const footerRef = useRef<HTMLDivElement>(null);
     const [isExporting, setIsExporting] = useState(false);
+
+    useEffect(() => {
+      loadAllowedAbbreviationsFromApi();
+    }, []);
 
     useEffect(() => {
       const calc = () => {

--- a/src/functions/checkURIContentDictionary.ts
+++ b/src/functions/checkURIContentDictionary.ts
@@ -1,23 +1,23 @@
 import { Diagnostic } from "@codemirror/lint";
 import { mapSeverity } from "@/utils/mapSeverity";
-import { splitPathIntoTokens, looksLikeAbbreviation, looksLikeUnknownWord, ALLOWED_ABBREVIATIONS } from "@/utils/englishWords";
+import { splitPathIntoTokens, looksLikeAbbreviation, looksLikeUnknownWord, getAllowedAbbreviations } from "@/utils/englishWords";
 
 export function checkURIContentDictionary(spec: any, content: string, rule: any): Diagnostic[] {
     const diagnostics: Diagnostic[] = [];
 
     if (!spec?.paths) return diagnostics;
 
-    const checkAbreviations = rule?.functionParams?.checkAbreviations ?? true;
-    const checkDictionary = rule?.functionParams?.checkDictionary ?? true;
+    const checkAbreviations = rule?.call.functionParams?.checkAbreviations ?? true;
+    const checkDictionary = rule?.call.functionParams?.checkDictionary ?? true;
 
-    const allowedAbbrevs = new Set<string>(ALLOWED_ABBREVIATIONS);
+    const allowedAbbrevs = getAllowedAbbreviations();
 
-    if (Array.isArray(rule?.functionParams?.allowedAbbreviations)) {
-        for (const a of rule.functionParams.allowedAbbreviations) {
+    if (Array.isArray(rule?.call.functionParams?.allowedAbbreviations)) {
+        for (const a of rule.call.functionParams.allowedAbbreviations) {
             if (typeof a === "string") allowedAbbrevs.add(a.toLowerCase());
         }
     }
-
+    console.error(allowedAbbrevs)
     for (const pathKey of Object.keys(spec.paths)) {
 
         const tokens = splitPathIntoTokens(pathKey);

--- a/src/functions/checkURIContentSyntax.ts
+++ b/src/functions/checkURIContentSyntax.ts
@@ -1,0 +1,44 @@
+import { Diagnostic } from "@codemirror/lint";
+import { mapSeverity } from "@/utils/mapSeverity";
+
+
+export function checkURIContentSyntax(spec: any, content: string, rule: any): Diagnostic[] {
+    const diagnostics: Diagnostic[] = [];
+
+    if (!spec?.paths) return diagnostics;
+
+    const patterns: string[] = rule?.call.functionParams?.requiredPathRegexp ?? [];
+
+    if (!patterns.length) return diagnostics;
+
+    // Precompile all regexes
+    const regexes = patterns
+        .map((p) => {
+            try {
+                return new RegExp(p);
+            } catch (e) {
+                console.error("Invalid requiredPathRegexp pattern in rule", rule?.id, p, e);
+                return null;
+            }
+        })
+        .filter((r): r is RegExp => r !== null);
+
+    if (!regexes.length) return diagnostics;
+
+    for (const pathKey of Object.keys(spec.paths)) {
+        // Check if this path matches at least one of the allowed patterns
+        const isValid = regexes.some((re) => re.test(pathKey));
+        if (!isValid) {
+            const index = content.indexOf(pathKey);
+            diagnostics.push({
+                from: index >= 0 ? index : 0,
+                to: index >= 0 ? index + pathKey.length : 0,
+                severity: mapSeverity(rule.severity),
+                message: `Path "${pathKey}" does not conform to the required URI syntax: resource names must be lowercase and separated by hyphens, and path parameters must be in {snake_case}.`,
+                source: rule.id,
+            });
+        }
+    }
+
+    return diagnostics;
+}

--- a/src/functions/checkURIFormat.ts
+++ b/src/functions/checkURIFormat.ts
@@ -7,7 +7,7 @@ export function checkURIFormat(spec: any, content: string, rule: any): Diagnosti
     if (!spec?.paths) return diagnostics;
 
     // Read allowed formats from rule params (if provided) so the rule is configurable
-    const scopeFormats = (rule?.functionParams?.allowedFormats?.scope ?? []) as Array<Record<string, string>>;
+    const scopeFormats = (rule?.call.functionParams?.allowedFormats?.scope ?? []) as Array<Record<string, string>>;
 
     let projectPattern = "";
     let domainPattern = "";

--- a/src/functions/checkURILength.ts
+++ b/src/functions/checkURILength.ts
@@ -22,7 +22,7 @@ export function checkURILength(spec: any, content: string, rule: any): Diagnosti
 
     if (!spec?.paths) return diagnostics;
 
-    const maxLength: number = rule?.functionParams?.maxLength ?? 2048;
+    const maxLength: number = rule?.call.functionParams?.maxLength ?? 2048;
 
     for (const pathKey of Object.keys(spec.paths)) {
         // Encode the path as a URI and measure its byte length (UTF-8)

--- a/src/lib/linter/runLinter.ts
+++ b/src/lib/linter/runLinter.ts
@@ -18,6 +18,7 @@ import { checkCompatibility } from '@/functions/checkCompatibility';
 import { checkURIFormat } from '@/functions/checkURIFormat';
 import { checkURILength } from '@/functions/checkURILength';
 import { checkURIContentDictionary } from '@/functions/checkURIContentDictionary';
+import { checkURIContentSyntax } from '@/functions/checkURIContentSyntax';
 
 export const functionsMap: {
   [key: string]: (spec: any, content: string, rule: any) => Diagnostic[] | Promise<Diagnostic[]>;
@@ -38,7 +39,8 @@ export const functionsMap: {
   checkCompatibility,
   checkURIFormat,
   checkURILength,
-  checkURIContentDictionary
+  checkURIContentDictionary,
+  checkURIContentSyntax
 };
 
 /**

--- a/src/pages/api/abbreviations.ts
+++ b/src/pages/api/abbreviations.ts
@@ -1,0 +1,41 @@
+import path from "path";
+import fs from "fs/promises";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+    req: NextApiRequest,
+    res: NextApiResponse<string[] | { error: string }>
+) {
+    try {
+        // Build absolute path to the abbreviations file under public/lib
+        const filePath = path.join(process.cwd(), "public", "lib", "allowed_abbreviations");
+
+        const content = await fs.readFile(filePath, "utf-8");
+        const abbreviations: string[] = [];
+
+        // Primary parsing: extract quoted tokens like "id", 'api', etc.
+        const regex = /["']([^"']+)["']/g;
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(content)) !== null) {
+            const token = match[1].trim();
+            if (token) {
+                abbreviations.push(token);
+            }
+        }
+
+        // Fallback: if no quoted tokens were found, try comma-separated values
+        if (abbreviations.length === 0) {
+            content.split(",").forEach((part) => {
+                const cleaned = part.trim().replace(/^["']|["']$/g, "");
+                if (cleaned) {
+                    abbreviations.push(cleaned);
+                }
+            });
+        }
+
+        res.status(200).json(abbreviations);
+    } catch (error) {
+        console.error("Failed to load abbreviations:", error);
+        res.status(500).json({ error: "Failed to load abbreviations" });
+    }
+}

--- a/src/utils/englishWords.ts
+++ b/src/utils/englishWords.ts
@@ -1,30 +1,26 @@
 import englishWords from "an-array-of-english-words";
 
-// Load allowed abbreviations from file in public/lib/allowed_abbreviations
-function loadAllowedAbbreviations(): Set<string> {
-  try {
-    const request = new XMLHttpRequest();
-    request.open("GET", "/lib/allowed_abbreviations", false);
-    request.send(null);
+let ALLOWED_ABBREVIATIONS = new Set<string>();
 
-    if (request.status >= 200 && request.status < 300) {
-      const content = request.responseText;
-      const lines = content
-        .split(/\r?\n/)
-        .map((l) => l.trim().toLowerCase())
-        .filter((l) => !!l && !l.startsWith("#"));
-      return new Set<string>(lines);
-    }
-
-    console.error("Failed to load allowed abbreviations, status:", request.status);
-    return new Set<string>();
-  } catch (err) {
-    console.error("Failed to load allowed abbreviations:", err);
-    return new Set<string>();
-  }
+export function getAllowedAbbreviations(): Set<string> {
+  return ALLOWED_ABBREVIATIONS;
 }
 
-export const ALLOWED_ABBREVIATIONS = loadAllowedAbbreviations();
+export async function loadAllowedAbbreviationsFromApi() {
+  try {
+    const res = await fetch("/api/abbreviations");
+    if (!res.ok) {
+      console.error("Failed to fetch abbreviations:", res.status);
+      return;
+    }
+    const data: string[] = await res.json();
+    ALLOWED_ABBREVIATIONS = new Set(
+      data.map((abbr) => abbr.toLowerCase())
+    );
+  } catch (err) {
+    console.error("Failed to fetch abbreviations:", err);
+  }
+}
 
 // Load full English dictionary from an-array-of-english-words
 const ENGLISH_DICTIONARY = new Set<string>(


### PR DESCRIPTION
implements:
  - id: "URI-020-01-2507-2507-M-3"
    title: URIs allow only nouns and use lowercase letters. Use few concatenated words.
    message: |
      Resource names in URIs must be separated by hyphens (-) and all letters must be lowercase.
fix:
  - abbreviations read
  - functions parameters read